### PR TITLE
Syntax/style fixes (adding bashisms)

### DIFF
--- a/bin/pantry
+++ b/bin/pantry
@@ -26,50 +26,48 @@
 #
 # Any failing command run by this script may cause it to exit (or not)
 # and return its own exit code (or 0).
-if [ $USER != 'root' ]; then
+if [[ $USER != 'root' ]]; then
     echo 'You must execute this script as root.'
     echo "sudo ${0}"
     exit 100
 fi
 
+run_chef=
 while getopts c opt
 do
     case "$opt" in
-        c) run_chef=true;;
+        c) run_chef=1;;
     esac
 done
-shift `expr $OPTIND - 1`
+shift $((OPTIND - 1))
 
-if [ ! -f /opt/chefdk/version-manifest.txt ]; then
-    echo ''
+if [[ ! -f /opt/chefdk/version-manifest.txt ]]; then
+    echo
     echo 'Downloading ChefDK.'
     curl -L https://www.chef.io/chef/install.sh | bash -s -- -P chefdk
-    if [ $? -ne 0 ]; then
+    if [[ $? -ne 0 ]]; then
         echo 'Failed to install ChefDK. Exiting!'
         exit 110
     fi
 fi
 
-if [ ! -f Berksfile.lock ]
-then
+if [[ ! -f Berksfile.lock ]]; then
     echo 'Vendoring cookbooks with Berkshelf.'
     berks vendor && chmod 0644 Berksfile.lock
-    if [ $? -ne 0 ]
-    then
-        echo ''
+    if [[ $? -ne 0 ]]; then
+        echo
         echo 'Berkshelf failed to vendor required cookbooks!'
         exit 120
     fi
-    echo ''
+    echo
 fi
 
-if [ "x$run_chef" = "xtrue" ]
-then
-    echo 'Running `chef-client` with the pantry default recipe.'
+if [[ -n $run_chef ]]; then
+    echo 'Running chef-client with the pantry default recipe.'
     /opt/chefdk/embedded/bin/chef-client -z -o 'recipe[pantry]'
 else
-    echo ''
-    echo 'To have this script automatically run Chef with the `base` role, run'
+    echo
+    echo 'To have this script automatically run Chef with the base role, run'
     echo "'$0 -c'"
     exit 0
 fi


### PR DESCRIPTION
We explicitly require bash, so we can use better features/style and do away
with some things done for compatibility.

* Use [[ instead of [ for conditions
* Initialize variables set by command line arguments beforehand just in case
  they're set in the user's environment.
* Don't use "xfoo" == "xtrue" - the x to guard against blank variables isn't
  needed any more.
* The removal of `` from the echo is just to silence a warning from shellcheck
  which falsely thinks you wanted to do command expansion inside single
  quotes.
* Use $((...)) instead of `expr` to do arithmetic (doesn't spawn a subshell)
* Set run_chef to 1 instead of true, and just check to see if it is non-empty
  with -n instead of explicitly doing string comparison (it makes the
  condition a little more readable)

Some of these are more style differences than 'use this because bash gives us better features', but hopefully this makes things look a little cleaner.