### PR TITLE
Add the ability to override the run_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ To perform the installation and run Chef with the "base" role, use the `-c` opti
 sudo ./bin/pantry -c
 ```
 
+To perform the installation and run Chef with a *specific* role, use the `-r` option with the name of the role in quotes.
+
+```
+sudo ./bin/pantry -c -r "role[dev-workstation]"
+```
+
 ### Installing Packages
 
 Packages are installed by populating attribute arrays with a list of names to install. For OS X, these are handled by the `homebrew` cookbook's formulas and casks attributes. For example, update `dna.json` with the following content:

--- a/bin/pantry
+++ b/bin/pantry
@@ -32,11 +32,13 @@ if [ $USER != 'root' ]; then
     exit 100
 fi
 
+run_list='recipe[pantry]'
 while getopts cu opt
 do
     case "$opt" in
         c) run_chef=true;;
         u) upgrade=true;;
+        r) run_list="$OPTARG";;
     esac
 done
 shift `expr $OPTIND - 1`
@@ -80,8 +82,8 @@ fi
 
 if [ "x$run_chef" = "xtrue" ]
 then
-    echo 'Running `chef-client` with the pantry default recipe.'
-    /opt/chefdk/embedded/bin/chef-client -z -r 'recipe[pantry]'
+    echo "Running \`chef-client\` with the $run_list."
+    /opt/chefdk/embedded/bin/chef-client -z -r "$run_list"
 else
     echo 'To have this script automatically run Chef with the "base" role, run:'
     echo "$0 -c"


### PR DESCRIPTION
This would previously default to just running `recipe[pantry]`. It's useful to have this lightweight wrapper around running chef locally as users can install `chef-client` through other tooling - potentially as an accidental dependency - and therefore muck up the running of `chef-client` through $PATH manipulation.