### PR TITLE
Fixes #14 Use Policyfiles

### DIFF
--- a/.chef/config.rb
+++ b/.chef/config.rb
@@ -1,11 +1,9 @@
 current_dir = File.dirname(__FILE__)
-json_attribs_file = File.join(current_dir, '..', 'dna.json')
-# https://github.com/opscode/chef/issues/2449
-chef_repo_path File.join(current_dir, '..')
+# https://github.com/chef/chef/issues/2449
+chef_repo_path File.join(current_dir, '..', 'zero-repo')
 
-json_attribs json_attribs_file if File.exist?(json_attribs_file)
-
-cookbook_path [
-  File.expand_path(File.join(current_dir, '..', 'cookbooks')),
-  File.expand_path(File.join(current_dir, '..', 'berks-cookbooks'))
-]
+# We'll use policyfiles with local mode.
+use_policyfile true
+deployment_group 'pantry-local'
+versioned_cookbooks true
+policy_document_native_api false

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ dna.json
 # Vagrant
 Vagrantfile
 .vagrant/
+
+# Policyfile
+Policyfile.lock.json
+zero-repo

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,0 @@
-source 'https://supermarket.chef.io'
-
-cookbook 'pantry', '>= 0.2.1'

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,40 @@
+# Policyfile.rb - Describe how you want Chef to configure your workstation.
+#
+# For more information on the Policyfile feature, visit
+# https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+
+name 'pantry'
+# Get cookbooks from supermarket.chef.io
+default_source :community
+
+##########
+# Run List
+# chef-client will run these recipes in the order specified.
+# Modify this to include other cookbooks you wish to use, separating
+# each recipe name with commas. For example:
+#
+# run_list(
+#   'pantry',
+#   'mycookbook'
+# )
+#
+# Add `cookbook` entries for cookbooks that are not found on
+# supermarket. See the POLICYFILE_README.md for more information.
+
+run_list(
+  'pantry'
+)
+
+############
+# Attributes
+# Feel free to modify these values, or add your own attributes for
+# other cookbooks.
+# Specify values as a space separated list of words. For example,
+# %w(git go packer tree)
+#
+# packages for OS X
+default['homebrew']['casks']      = %w()
+default['homebrew']['formula']    = %w()
+default['homebrew']['taps']       = %w()
+# packages for Windows
+default['chocolatey']['packages'] = %w()

--- a/bin/pantry
+++ b/bin/pantry
@@ -32,14 +32,22 @@ if [ $USER != 'root' ]; then
     exit 100
 fi
 
-while getopts cu opt
+while getopts cup opt
 do
     case "$opt" in
         c) run_chef=true;;
         u) upgrade=true;;
+        p) prerelease=true;;
     esac
 done
 shift `expr $OPTIND - 1`
+
+if [ "x$prerelease" = "xtrue" ]
+then
+    preopt='-p'
+else
+    preopt=' '
+fi
 
 if [ "x$upgrade" = "xtrue" ]
 then
@@ -51,28 +59,35 @@ then
         # we don't bother with the links in `/usr/bin`.
         pkgutil --forget com.getchef.pkg.chefdk && rm -rf /opt/chefdk
     fi
-    echo 'Removing Berksfile.lock so cookbooks can be updated'
-    rm -f Berksfile.lock
+    echo 'Removing Policyfile.lock.json so cookbooks are upgraded too'
+    rm -f Policyfile.lock.json
 fi
 
 if [ ! -f /opt/chefdk/version-manifest.txt ]; then
     echo ''
     echo 'Downloading ChefDK.'
-    curl -L https://www.chef.io/chef/install.sh | bash -s -- -P chefdk
+    curl -L https://www.chef.io/chef/install.sh | bash -s -- $preopt -P chefdk
+
     if [ $? -ne 0 ]; then
         echo 'Failed to install ChefDK. Exiting!'
         exit 110
     fi
 fi
 
-if [ ! -f Berksfile.lock ]
+# We check that the Policyfile.rb exists first because someone might
+# download this script and run it without having the full repository.
+if [ -f Policyfile.rb ] && [ ! -f Policyfile.lock.json ]
 then
-    echo 'Vendoring cookbooks with Berkshelf.'
-    berks vendor && chmod 0644 Berksfile.lock
+    echo 'Installing Policy to ChefDK cookbook cache and exporting repository to zero-repo.'
+    chef install && chmod 0644 Policyfile.lock.json
+    chef export zero-repo --force
+
+    [ ! -z $SUDO_USER ] && chown -R $SUDO_USER Policyfile.lock.json zero-repo
+
     if [ $? -ne 0 ]
     then
         echo ''
-        echo 'Berkshelf failed to vendor required cookbooks!'
+        echo 'Chef Policyfile failed to install and export cookbooks!'
         exit 120
     fi
     echo ''
@@ -80,10 +95,13 @@ fi
 
 if [ "x$run_chef" = "xtrue" ]
 then
-    echo 'Running `chef-client` with the pantry default recipe.'
-    /opt/chefdk/embedded/bin/chef-client -z -r 'recipe[pantry]'
+    echo 'Running `chef-client` with the default Policyfile.rb.'
+    /opt/chefdk/embedded/bin/chef-client -z
+    echo 'In the future, you can modify the Policyfile.rb, then run'
+    echo '`chef update` and `chef export zero-repo`, then rerun chef client with'
+    echo '`sudo /opt/chefdk/embedded/bin/chef-client -z` from this directory.'
 else
-    echo 'To have this script automatically run Chef with the "pantry::default" recipe, run:'
+    echo 'To have this script automatically run Chef with the default Policyfile.rb, run:'
     echo "$0 -c"
     exit 0
 fi


### PR DESCRIPTION
As it turns out this enables a much easier work flow, and removes the
need for a bunch of open issues' features.

- Fixes #3: we no longer need a role.
- Fixes #5: we no longer need a node object, or dna.json.
- Fixes #13: Custom recipes can be added by customizing the Policyfile.rb
- Fixes #14: Converts from Berkshelf to Policyfile
- Fixes #17: The pantry script can be used safely without using the
  whole repository, but it is still recommended, to get the benefits of
  the Policyfile structure